### PR TITLE
Forward the `ClientRequestToken` as idempotency token to the `Create` API

### DIFF
--- a/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandler.java
+++ b/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandler.java
@@ -29,10 +29,12 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         final Logger logger) {
 
         final ResourceModel model = request.getDesiredResourceState();
+        final String idempotencyToken = request.getClientRequestToken();
 
         try {
             CreateProfilingGroupRequest createProfilingGroupRequest = CreateProfilingGroupRequest.builder()
                     .profilingGroupName(model.getProfilingGroupName())
+                    .clientToken(idempotencyToken)
                     .build();
 
             proxy.injectCredentialsAndInvokeV2(createProfilingGroupRequest, profilerClient::createProfilingGroup);

--- a/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandlerTest.java
+++ b/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandlerTest.java
@@ -63,7 +63,7 @@ public class CreateHandlerTest {
                 .when(proxy).injectCredentialsAndInvokeV2(
                     ArgumentMatchers.eq(CreateProfilingGroupRequest
                         .builder()
-                        .profilingGroupName("IronMan-Suit-34")
+                        .profilingGroupName("IronMan-Suit-34").clientToken("clientTokenXXX")
                         .build()), any());
 
         final ProgressEvent<ResourceModel, CallbackContext> response

--- a/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/RequestBuilder.java
+++ b/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/RequestBuilder.java
@@ -12,6 +12,6 @@ public class RequestBuilder {
     }
 
     static ResourceHandlerRequest<ResourceModel> makeRequest(ResourceModel model) {
-        return ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+        return ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).clientRequestToken("clientTokenXXX").build();
     }
 }


### PR DESCRIPTION

Based on https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html we need to forward the `ClientRequestToken` as idempotency token to our API.

> All handlers MUST be idempotent when called using the same `ClientRequestToken`.

**Test**

I run:
```
pre-commit run --all-files && AWS_REGION=us-east-1 mvn clean package
```
and also created/deleted a stack in my burner account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
