### PR TITLE
Log accountId whenever the Create/DeleteHandlers are called

### DIFF
--- a/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandler.java
+++ b/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandler.java
@@ -40,7 +40,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
 
             proxy.injectCredentialsAndInvokeV2(createProfilingGroupRequest, profilerClient::createProfilingGroup);
 
-            logger.log(String.format("%s [%s] for accountId %s has been successfully created!", ResourceModel.TYPE_NAME, model.getProfilingGroupName(), awsAccountId));
+            logger.log(String.format("%s [%s] for accountId [%s] has been successfully created!", ResourceModel.TYPE_NAME, model.getProfilingGroupName(), awsAccountId));
 
             return ProgressEvent.defaultSuccessHandler(model);
         } catch (ConflictException e) {

--- a/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/DeleteHandler.java
+++ b/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/DeleteHandler.java
@@ -36,7 +36,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
 
             proxy.injectCredentialsAndInvokeV2(deleteProfilingGroupRequest, profilerClient::deleteProfilingGroup);
 
-            logger.log(String.format("%s [%s] for accountId %s has been successfully deleted!", ResourceModel.TYPE_NAME, model.getProfilingGroupName(), awsAccountId));
+            logger.log(String.format("%s [%s] for accountId [%s] has been successfully deleted!", ResourceModel.TYPE_NAME, model.getProfilingGroupName(), awsAccountId));
 
             return ProgressEvent.defaultSuccessHandler(model);
 

--- a/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/ListHandler.java
+++ b/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/ListHandler.java
@@ -28,6 +28,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
         final Logger logger) {
 
         final List<ResourceModel> models = new ArrayList<>();
+        final String awsAccountId = request.getAwsAccountId();
 
         try {
             ListProfilingGroupsRequest listProfilingGroupsRequest = ListProfilingGroupsRequest.builder()
@@ -44,7 +45,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                             .arn(pg.arn()).build())
             );
 
-            logger.log(String.format("%d \"%s\" has been successfully listed for token %s!", models.size(), ResourceModel.TYPE_NAME, request.getNextToken()));
+            logger.log(String.format("%d \"%s\" for accountId [%s] has been successfully listed for token %s!", models.size(), ResourceModel.TYPE_NAME, awsAccountId, request.getNextToken()));
 
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
                     .resourceModels(models)

--- a/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/ReadHandler.java
+++ b/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/ReadHandler.java
@@ -28,6 +28,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         final Logger logger) {
 
         final ResourceModel model = request.getDesiredResourceState();
+        final String awsAccountId = request.getAwsAccountId();
 
         try {
             DescribeProfilingGroupRequest describeProfilingGroupRequest = DescribeProfilingGroupRequest.builder()
@@ -38,7 +39,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
             model.setProfilingGroupName(response.profilingGroup().name()); // This is not needed but making sure the response is the same as the request!
             model.setArn(response.profilingGroup().arn());
 
-            logger.log(String.format("%s [%s] has been successfully read!", ResourceModel.TYPE_NAME, model.getProfilingGroupName()));
+            logger.log(String.format("%s [%s] for accountId [%s] has been successfully read!", ResourceModel.TYPE_NAME, model.getProfilingGroupName(), awsAccountId));
 
             return ProgressEvent.defaultSuccessHandler(model);
 

--- a/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/RequestBuilder.java
+++ b/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/RequestBuilder.java
@@ -12,6 +12,6 @@ public class RequestBuilder {
     }
 
     static ResourceHandlerRequest<ResourceModel> makeRequest(ResourceModel model) {
-        return ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).clientRequestToken("clientTokenXXX").build();
+        return ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).clientRequestToken("clientTokenXXX").awsAccountId("111111111111").build();
     }
 }


### PR DESCRIPTION
Logging accountId when CreateHandler and DeleteHandler are called so that we can have more information on which customers are onboarding through cloudformation.

I did not add them on ListHandler and ReadHandler as they do not contain awsAccountId in their request. (null is shown when I included them in the log)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.