### PR TITLE
Upgrade awssdk version to 2.13.16 on pom.xml

### DIFF
--- a/aws-codeguruprofiler-profilinggroup/pom.xml
+++ b/aws-codeguruprofiler-profilinggroup/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
@@ -74,9 +74,19 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>codeguruprofiler</artifactId>
-            <version>2.10.63</version>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.13.16</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
There are several new CodeGuru-Profiler operations supported in
2.13.16 so it is important to upgrade the awssdk version.

*Description of changes:*

I have upgraded the version of `aws-cloudformation-rpdk-java-plugin` from 1.0.2 to 1.0.5 and also, 
created a dependencyManagement section to make sure all dependency under groupId `software.amazon.awssdk` are in the same version. In the meantime, I have upgraded the version of awssdk to 2.13.16 as there are new features rolled out from CodeGuruProfiler team on the latest version of awssdk.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
