### PR TITLE
Add support for AgentPermissions in CloudFormation (UpdateHandler)

### DIFF
--- a/aws-codeguruprofiler-profilinggroup/aws-codeguruprofiler-profilinggroup.json
+++ b/aws-codeguruprofiler-profilinggroup/aws-codeguruprofiler-profilinggroup.json
@@ -70,6 +70,13 @@
         "codeguru-profiler:DescribeProfilingGroup"
       ]
     },
+    "update": {
+      "permissions": [
+        "codeguru-profiler:PutPermission",
+        "codeguru-profiler:RemovePermission",
+        "codeguru-profiler:GetPolicy"
+      ]
+    },
     "delete": {
       "permissions": [
         "codeguru-profiler:DeleteProfilingGroup"

--- a/aws-codeguruprofiler-profilinggroup/resource-role.yaml
+++ b/aws-codeguruprofiler-profilinggroup/resource-role.yaml
@@ -26,8 +26,10 @@ Resources:
                 - "codeguru-profiler:CreateProfilingGroup"
                 - "codeguru-profiler:DeleteProfilingGroup"
                 - "codeguru-profiler:DescribeProfilingGroup"
+                - "codeguru-profiler:GetPolicy"
                 - "codeguru-profiler:ListProfilingGroups"
                 - "codeguru-profiler:PutPermission"
+                - "codeguru-profiler:RemovePermission"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/UpdateHandler.java
+++ b/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/UpdateHandler.java
@@ -1,0 +1,107 @@
+package software.amazon.codeguruprofiler.profilinggroup;
+
+import software.amazon.awssdk.services.codeguruprofiler.CodeGuruProfilerClient;
+import software.amazon.awssdk.services.codeguruprofiler.model.ActionGroup;
+import software.amazon.awssdk.services.codeguruprofiler.model.ConflictException;
+import software.amazon.awssdk.services.codeguruprofiler.model.GetPolicyRequest;
+import software.amazon.awssdk.services.codeguruprofiler.model.GetPolicyResponse;
+import software.amazon.awssdk.services.codeguruprofiler.model.InternalServerException;
+import software.amazon.awssdk.services.codeguruprofiler.model.PutPermissionRequest;
+import software.amazon.awssdk.services.codeguruprofiler.model.RemovePermissionRequest;
+import software.amazon.awssdk.services.codeguruprofiler.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.codeguruprofiler.model.ThrottlingException;
+import software.amazon.awssdk.services.codeguruprofiler.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.CfnThrottlingException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.List;
+
+public class UpdateHandler extends BaseHandler<CallbackContext> {
+
+    private final CodeGuruProfilerClient profilerClient = CodeGuruProfilerClientBuilder.create();
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        AmazonWebServicesClientProxy proxy,
+        ResourceHandlerRequest<ResourceModel> request,
+        CallbackContext callbackContext,
+        Logger logger) {
+        final ResourceModel model = request.getDesiredResourceState();
+
+        final String awsAccountId = request.getAwsAccountId();
+        final String profilingGroupName = model.getProfilingGroupName();
+
+        Permissions newPermissions = model.getPermissions();
+
+        try {
+            if (newPermissions != null) {
+                // if permission exists in Cfn
+                // TODO: Handle cases when Permission/ AgentPermissions/ Principals contains empty body
+                List<String> principals = newPermissions.getAgentPermissions().getPrincipals();
+                putAgentPermissions(proxy, profilingGroupName, principals);
+                logger.log(
+                    String.format("Policy for [%s] for accountId [%s] has been successfully updated! actionGroup: %s, principals: %s",
+                        profilingGroupName,
+                        awsAccountId,
+                        ActionGroup.AGENT_PERMISSIONS,
+                        principals)
+                );
+            } else {
+                // if permission does not exist in Cfn
+                GetPolicyRequest getPolicyRequest = GetPolicyRequest.builder().profilingGroupName(profilingGroupName).build();
+                GetPolicyResponse getPolicyResponse = proxy.injectCredentialsAndInvokeV2(getPolicyRequest, profilerClient::getPolicy);
+
+                // If policy does not exist, it would be null
+                if (getPolicyResponse.policy() != null) {
+                    removeAgentPermission(proxy, profilingGroupName, getPolicyResponse.revisionId());
+                    logger.log(String.format("Policy for [%s] for accountId [%s] has been successfully removed!", profilingGroupName, awsAccountId));
+                }
+            }
+
+            logger.log(String.format("%s [%s] for accountId [%s] has been successfully updated!", ResourceModel.TYPE_NAME, model.getProfilingGroupName(), awsAccountId));
+
+            return ProgressEvent.defaultSuccessHandler(model);
+        } catch (ConflictException e) {
+            throw new CfnAlreadyExistsException(e);
+        } catch (InternalServerException e) {
+            throw new CfnServiceInternalErrorException(e);
+        } catch (ResourceNotFoundException e) {
+            throw new CfnNotFoundException(e);
+        } catch (ThrottlingException e) {
+            throw new CfnThrottlingException(e);
+        } catch (ValidationException e) {
+            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+        }
+    }
+
+    private void putAgentPermissions(AmazonWebServicesClientProxy proxy,
+                                     String profilingGroupName,
+                                     List<String> principals) {
+        PutPermissionRequest putPermissionRequest = PutPermissionRequest.builder()
+                                                        .profilingGroupName(profilingGroupName)
+                                                        .actionGroup(ActionGroup.AGENT_PERMISSIONS)
+                                                        .principals(principals)
+                                                        .build();
+
+        proxy.injectCredentialsAndInvokeV2(putPermissionRequest, profilerClient::putPermission);
+    }
+
+    private void removeAgentPermission(AmazonWebServicesClientProxy proxy,
+                                       String profilingGroupName,
+                                       String revisionId) {
+        RemovePermissionRequest removePermissionRequest = RemovePermissionRequest.builder()
+                                                              .profilingGroupName(profilingGroupName)
+                                                              .actionGroup(ActionGroup.AGENT_PERMISSIONS)
+                                                              .revisionId(revisionId)
+                                                              .build();
+
+        proxy.injectCredentialsAndInvokeV2(removePermissionRequest, profilerClient::removePermission);
+    }
+}

--- a/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/UpdateHandlerTest.java
+++ b/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/UpdateHandlerTest.java
@@ -1,0 +1,267 @@
+package software.amazon.codeguruprofiler.profilinggroup;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import software.amazon.awssdk.services.codeguruprofiler.model.ActionGroup;
+import software.amazon.awssdk.services.codeguruprofiler.model.ConflictException;
+import software.amazon.awssdk.services.codeguruprofiler.model.GetPolicyRequest;
+import software.amazon.awssdk.services.codeguruprofiler.model.GetPolicyResponse;
+import software.amazon.awssdk.services.codeguruprofiler.model.InternalServerException;
+import software.amazon.awssdk.services.codeguruprofiler.model.PutPermissionRequest;
+import software.amazon.awssdk.services.codeguruprofiler.model.PutPermissionResponse;
+import software.amazon.awssdk.services.codeguruprofiler.model.RemovePermissionRequest;
+import software.amazon.awssdk.services.codeguruprofiler.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.codeguruprofiler.model.ThrottlingException;
+import software.amazon.awssdk.services.codeguruprofiler.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.CfnThrottlingException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static software.amazon.codeguruprofiler.profilinggroup.RequestBuilder.makeRequest;
+import static software.amazon.codeguruprofiler.profilinggroup.RequestBuilder.makeValidRequest;
+
+public class UpdateHandlerTest {
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    private Logger logger;
+
+    private UpdateHandler subject;
+
+    private ResourceHandlerRequest<ResourceModel> request;
+
+    private final String profilingGroupName = "IronMan-2020";
+
+    private final String revisionId = "TestRevisionId-123";
+
+    private final GetPolicyRequest getPolicyRequest =
+        GetPolicyRequest.builder().profilingGroupName(profilingGroupName).build();
+
+    private final List<String> principals = Arrays.asList("arn:aws:iam::123456789012:role/UnitTestRole");
+
+    @BeforeEach
+    public void setup() {
+        proxy = mock(AmazonWebServicesClientProxy.class);
+        logger = mock(Logger.class);
+        subject = new UpdateHandler();
+    }
+
+    @Nested
+    class WhenNoPermissionsIsProvided {
+        @BeforeEach
+        public void setup() {
+            request =  makeRequest(ResourceModel.builder().profilingGroupName(profilingGroupName).build());
+            doReturn(GetPolicyResponse.builder().build())
+                .when(proxy).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
+        }
+
+        @Test
+        public void testSuccess() {
+            final ProgressEvent<ResourceModel, CallbackContext> response
+                = subject.handleRequest(proxy, request, null, logger);
+
+            assertThat(response).isNotNull();
+            assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+            assertThat(response.getCallbackContext()).isNull();
+            assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+            assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+            assertThat(response.getMessage()).isNull();
+            assertThat(response.getErrorCode()).isNull();
+        }
+
+        @Test
+        public void testCorrectOperationIsCalled() {
+            subject.handleRequest(proxy, request, null, logger);
+
+            verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
+            verifyNoMoreInteractions(proxy);
+        }
+
+        @Nested
+        class WhenPolicyWasAttached {
+            @BeforeEach
+            public void setup() {
+                doReturn(
+                    GetPolicyResponse.builder()
+                        .policy("RandomString")
+                        .revisionId(revisionId)
+                        .build()
+                ).when(proxy).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
+            }
+
+            @Test
+            public void testCorrectOperationsAreCalled() {
+                subject.handleRequest(proxy, request, null, logger);
+
+                verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
+                verify(proxy, times(1)).injectCredentialsAndInvokeV2(
+                    eq(RemovePermissionRequest.builder()
+                           .profilingGroupName(profilingGroupName)
+                           .actionGroup(ActionGroup.AGENT_PERMISSIONS)
+                           .revisionId(revisionId)
+                           .build()
+                    ),
+                    any());
+                verifyNoMoreInteractions(proxy);
+            }
+        }
+    }
+
+    @Nested
+    class WhenPermissionsIsProvided {
+        private final PutPermissionRequest putPermissionRequest =
+            PutPermissionRequest.builder()
+                .profilingGroupName(profilingGroupName)
+                .actionGroup(ActionGroup.AGENT_PERMISSIONS)
+                .principals(principals)
+                .build();
+
+        @BeforeEach
+        public void setup() {
+            request =  makeRequest(
+                ResourceModel.builder()
+                    .profilingGroupName(profilingGroupName)
+                    .permissions(
+                        Permissions.builder()
+                            .agentPermissions(
+                                AgentPermissions.builder()
+                                    .principals(principals)
+                                    .build()
+                            )
+                            .build()
+                    )
+                    .build()
+            );
+            doReturn(GetPolicyResponse.builder().build())
+                .when(proxy).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
+            doReturn(PutPermissionResponse.builder().build())
+                .when(proxy).injectCredentialsAndInvokeV2(eq(putPermissionRequest), any());
+        }
+
+        @Test
+        public void testSuccess() {
+            final ProgressEvent<ResourceModel, CallbackContext> response
+                = subject.handleRequest(proxy, request, null, logger);
+
+            assertThat(response).isNotNull();
+            assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+            assertThat(response.getCallbackContext()).isNull();
+            assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+            assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+            assertThat(response.getMessage()).isNull();
+            assertThat(response.getErrorCode()).isNull();
+        }
+
+        @Test
+        public void testCorrectOperationsAreCalled() {
+            subject.handleRequest(proxy, request, null, logger);
+
+            verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
+            verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(putPermissionRequest), any());
+            verifyNoMoreInteractions(proxy);
+        }
+
+        @Nested
+        class WhenPolicyWasAttached {
+            private final PutPermissionRequest putPermissionRequest =
+                PutPermissionRequest.builder()
+                    .profilingGroupName(profilingGroupName)
+                    .actionGroup(ActionGroup.AGENT_PERMISSIONS)
+                    .principals(principals)
+                    .revisionId(revisionId)
+                    .build();
+
+            @BeforeEach
+            public void setup() {
+                doReturn(GetPolicyResponse.builder()
+                             .policy("RandomString")
+                             .revisionId(revisionId)
+                             .build()
+                ).when(proxy).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
+
+                doReturn(PutPermissionResponse.builder().build())
+                    .when(proxy).injectCredentialsAndInvokeV2(eq(putPermissionRequest), any());
+            }
+
+            @Test
+            public void testCorrectOperationsAreCalled() {
+                subject.handleRequest(proxy, request, null, logger);
+
+                verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
+                verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(putPermissionRequest), any());
+                verifyNoMoreInteractions(proxy);
+            }
+        }
+    }
+
+    @Nested
+    class WhenThereIsAnException {
+        @BeforeEach
+        public void setup() {
+            request =  makeValidRequest();
+        }
+
+        @Test
+        public void testConflictException() {
+            doThrow(ConflictException.builder().build())
+                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+
+            assertThrows(CfnAlreadyExistsException.class, () -> subject.handleRequest(proxy, request, null, logger));
+        }
+
+        @Test
+        public void testNotFoundException() {
+            doThrow(ResourceNotFoundException.builder().build())
+                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+
+            assertThrows(CfnNotFoundException.class, () -> subject.handleRequest(proxy, request, null, logger));
+        }
+
+        @Test
+        public void testInternalServerException() {
+            doThrow(InternalServerException.builder().build())
+                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+
+            assertThrows(CfnServiceInternalErrorException.class, () -> subject.handleRequest(proxy, request, null, logger));
+        }
+
+        @Test
+        public void testThrottlingException() {
+            doThrow(ThrottlingException.builder().build())
+                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+
+            assertThrows(CfnThrottlingException.class, () -> subject.handleRequest(proxy, request, null, logger));
+        }
+
+        @Test
+        public void testValidationException() {
+            doThrow(ValidationException.builder().build())
+                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+
+            assertThrows(CfnInvalidRequestException.class, () -> subject.handleRequest(proxy, request, null, logger));
+        }
+    }
+}

--- a/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/UpdateHandlerTest.java
+++ b/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/UpdateHandlerTest.java
@@ -44,12 +44,12 @@ import static software.amazon.codeguruprofiler.profilinggroup.RequestBuilder.mak
 
 public class UpdateHandlerTest {
     @Mock
-    private AmazonWebServicesClientProxy proxy;
+    private AmazonWebServicesClientProxy proxy = mock(AmazonWebServicesClientProxy.class);
 
     @Mock
-    private Logger logger;
+    private Logger logger = mock(Logger.class);
 
-    private UpdateHandler subject;
+    private UpdateHandler subject = new UpdateHandler();
 
     private ResourceHandlerRequest<ResourceModel> request;
 
@@ -61,13 +61,6 @@ public class UpdateHandlerTest {
         GetPolicyRequest.builder().profilingGroupName(profilingGroupName).build();
 
     private final List<String> principals = Arrays.asList("arn:aws:iam::123456789012:role/UnitTestRole");
-
-    @BeforeEach
-    public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        logger = mock(Logger.class);
-        subject = new UpdateHandler();
-    }
 
     @Nested
     class WhenNoPermissionsIsProvided {
@@ -83,7 +76,6 @@ public class UpdateHandlerTest {
             final ProgressEvent<ResourceModel, CallbackContext> response
                 = subject.handleRequest(proxy, request, null, logger);
 
-            assertThat(response).isNotNull();
             assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
             assertThat(response.getCallbackContext()).isNull();
             assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
@@ -93,7 +85,7 @@ public class UpdateHandlerTest {
         }
 
         @Test
-        public void testCorrectOperationIsCalled() {
+        public void itOnlyCallsGetPolicy() {
             subject.handleRequest(proxy, request, null, logger);
 
             verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
@@ -113,7 +105,7 @@ public class UpdateHandlerTest {
             }
 
             @Test
-            public void testCorrectOperationsAreCalled() {
+            public void itCallsGetPolicyAndRemovePermissions() {
                 subject.handleRequest(proxy, request, null, logger);
 
                 verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
@@ -144,15 +136,7 @@ public class UpdateHandlerTest {
             request =  makeRequest(
                 ResourceModel.builder()
                     .profilingGroupName(profilingGroupName)
-                    .permissions(
-                        Permissions.builder()
-                            .agentPermissions(
-                                AgentPermissions.builder()
-                                    .principals(principals)
-                                    .build()
-                            )
-                            .build()
-                    )
+                    .agentPermissions(AgentPermissions.builder().principals(principals).build())
                     .build()
             );
             doReturn(GetPolicyResponse.builder().build())
@@ -166,7 +150,6 @@ public class UpdateHandlerTest {
             final ProgressEvent<ResourceModel, CallbackContext> response
                 = subject.handleRequest(proxy, request, null, logger);
 
-            assertThat(response).isNotNull();
             assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
             assertThat(response.getCallbackContext()).isNull();
             assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
@@ -176,7 +159,7 @@ public class UpdateHandlerTest {
         }
 
         @Test
-        public void testCorrectOperationsAreCalled() {
+        public void itCallsGetPolicyAndPutPermissions() {
             subject.handleRequest(proxy, request, null, logger);
 
             verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
@@ -207,7 +190,7 @@ public class UpdateHandlerTest {
             }
 
             @Test
-            public void testCorrectOperationsAreCalled() {
+            public void itCallsGetPolicyAndPutPermission() {
                 subject.handleRequest(proxy, request, null, logger);
 
                 verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(getPolicyRequest), any());
@@ -225,7 +208,7 @@ public class UpdateHandlerTest {
         }
 
         @Test
-        public void testConflictException() {
+        public void itThrowsConflictException() {
             doThrow(ConflictException.builder().build())
                 .when(proxy).injectCredentialsAndInvokeV2(any(), any());
 
@@ -233,7 +216,7 @@ public class UpdateHandlerTest {
         }
 
         @Test
-        public void testNotFoundException() {
+        public void itThrowsNotFoundException() {
             doThrow(ResourceNotFoundException.builder().build())
                 .when(proxy).injectCredentialsAndInvokeV2(any(), any());
 
@@ -241,7 +224,7 @@ public class UpdateHandlerTest {
         }
 
         @Test
-        public void testInternalServerException() {
+        public void itThrowsInternalServerException() {
             doThrow(InternalServerException.builder().build())
                 .when(proxy).injectCredentialsAndInvokeV2(any(), any());
 
@@ -249,7 +232,7 @@ public class UpdateHandlerTest {
         }
 
         @Test
-        public void testThrottlingException() {
+        public void itThrowsThrottlingException() {
             doThrow(ThrottlingException.builder().build())
                 .when(proxy).injectCredentialsAndInvokeV2(any(), any());
 
@@ -257,7 +240,7 @@ public class UpdateHandlerTest {
         }
 
         @Test
-        public void testValidationException() {
+        public void itThrowsValidationException() {
             doThrow(ValidationException.builder().build())
                 .when(proxy).injectCredentialsAndInvokeV2(any(), any());
 


### PR DESCRIPTION
*Description of changes:*
This includes updates for the schema, to the UpdateHandler resource and its related unit test.

Note that this CR will not be merged before https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-codeguru-profiler/pull/10 as both changes are required to be released together.

Testing was done as suggested in the README.md file and also the following test cases:

1. Create PG through CF -> Update CF: adding permission to the PG which does not have any permission before -> Update CF: removing permission that was previously added -> Remove CF: Clean up PG

2. Create PG through CF -> Update CF: adding permission with empty content -> `Internal Failure` -> Update CF: adding permission with empty agentPermissions -> `Invalid request provided: AWS::CodeGuruProfiler::ProfilingGroup1 validation error detected: Value null at 'principals' failed to satisfy constraint: Member must not be null` -> Update CF: adding permission with agentPermissions with empty Principals -> `Invalid request provided: AWS::CodeGuruProfiler::ProfilingGroup1 validation error detected: Value '[]' at 'principals' failed to satisfy constraint: Member must have length greater than or equal to 1`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
