### PR TITLE
Add cloudformation support for creating lambda profiling groups

### DIFF
--- a/aws-codeguruprofiler-profilinggroup/README.md
+++ b/aws-codeguruprofiler-profilinggroup/README.md
@@ -71,4 +71,4 @@ pre-commit run --all-files && AWS_REGION=us-east-1 mvn clean verify package
 
 #### Dealing with CI Failures
 If outside of Amazon, you will not be able to see the CI outputs. Our reviewers will be responsible for making that
-information available to you. Reviewers, you can find info on how to get CI outputs at [link](https://tinyurl.com/yagdpv7q).
+information available to you. Reviewers, you can find info on how to get CI outputs at [link](https://tiny.amazon.com/1in0t4ata).

--- a/aws-codeguruprofiler-profilinggroup/README.md
+++ b/aws-codeguruprofiler-profilinggroup/README.md
@@ -68,3 +68,7 @@ pre-commit run --all-files && AWS_REGION=us-east-1 mvn clean verify package
 #### Through SAM
 
 1. Follow instruction stated on [here](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-walkthrough.html#resource-type-walkthrough-test).
+
+#### Dealing with CI Failures
+If outside of Amazon, you will not be able to see the CI outputs. Our reviewers will be responsible for making that
+information available to you. Reviewers, you can find info on how to get CI outputs at [link](https://tinyurl.com/yagdpv7q).

--- a/aws-codeguruprofiler-profilinggroup/aws-codeguruprofiler-profilinggroup.json
+++ b/aws-codeguruprofiler-profilinggroup/aws-codeguruprofiler-profilinggroup.json
@@ -20,6 +20,14 @@
       "maxLength": 255,
       "pattern": "^[\\w-]+$"
     },
+    "ComputePlatform": {
+      "description": "The compute platform of the profiling group.",
+      "type": "string",
+      "enum": [
+        "Default",
+        "AWSLambda"
+      ]
+    },
     "AgentPermissions": {
       "description": "The agent permissions attached to this profiling group.",
       "type": "object",

--- a/aws-codeguruprofiler-profilinggroup/pom.xml
+++ b/aws-codeguruprofiler-profilinggroup/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.5</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-codeguruprofiler-profilinggroup/pom.xml
+++ b/aws-codeguruprofiler-profilinggroup/pom.xml
@@ -81,7 +81,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.13.16</version>
+                <version>2.13.47</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/aws-codeguruprofiler-profilinggroup/sample-template.json
+++ b/aws-codeguruprofiler-profilinggroup/sample-template.json
@@ -8,6 +8,20 @@
         "ProfilingGroupName": "MySampleProfilingGroup"
       }
     },
+    "MyProfilingGroupWithDefaultComputePlatform": {
+      "Type": "AWS::CodeGuruProfiler::ProfilingGroup",
+      "Properties": {
+        "ProfilingGroupName": "MyProfilingGroupWithDefaultComputePlatform",
+        "ComputePlatform": "Default"
+      }
+    },
+    "MyProfilingGroupWithLambdaComputePlatform": {
+      "Type": "AWS::CodeGuruProfiler::ProfilingGroup",
+      "Properties": {
+        "ProfilingGroupName": "MyProfilingGroupWithLambdaComputePlatform",
+        "ComputePlatform": "AWSLambda"
+      }
+    },
     "MyProfilingGroupWithAgentPermissions": {
       "Type": "AWS::CodeGuruProfiler::ProfilingGroup",
       "Properties": {

--- a/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandler.java
+++ b/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandler.java
@@ -42,16 +42,14 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         final String pgName = model.getProfilingGroupName();
         final String computePlatform = model.getComputePlatform();
 
-        CreateProfilingGroupRequest.Builder createProfilingGroupRequestBuilder = CreateProfilingGroupRequest.builder()
+        CreateProfilingGroupRequest createProfilingGroupRequest = CreateProfilingGroupRequest.builder()
             .profilingGroupName(pgName)
-            .clientToken(request.getClientRequestToken());
-
-        if (computePlatform != null) {
-            createProfilingGroupRequestBuilder.computePlatform(computePlatform);
-        }
+            .computePlatform(computePlatform)
+            .clientToken(request.getClientRequestToken())
+            .build();
 
         safelyInvokeApi(() -> {
-            proxy.injectCredentialsAndInvokeV2(createProfilingGroupRequestBuilder.build(), profilerClient::createProfilingGroup);
+            proxy.injectCredentialsAndInvokeV2(createProfilingGroupRequest, profilerClient::createProfilingGroup);
         });
         logger.log(format("%s [%s] for accountId [%s] has been successfully created!", ResourceModel.TYPE_NAME, pgName, awsAccountId));
 

--- a/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandler.java
+++ b/aws-codeguruprofiler-profilinggroup/src/main/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandler.java
@@ -40,13 +40,18 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         final String awsAccountId = request.getAwsAccountId();
         final ResourceModel model = request.getDesiredResourceState();
         final String pgName = model.getProfilingGroupName();
+        final String computePlatform = model.getComputePlatform();
 
-        CreateProfilingGroupRequest createProfilingGroupRequest = CreateProfilingGroupRequest.builder()
+        CreateProfilingGroupRequest.Builder createProfilingGroupRequestBuilder = CreateProfilingGroupRequest.builder()
             .profilingGroupName(pgName)
-            .clientToken(request.getClientRequestToken())
-            .build();
+            .clientToken(request.getClientRequestToken());
+
+        if (computePlatform != null) {
+            createProfilingGroupRequestBuilder.computePlatform(computePlatform);
+        }
+
         safelyInvokeApi(() -> {
-            proxy.injectCredentialsAndInvokeV2(createProfilingGroupRequest, profilerClient::createProfilingGroup);
+            proxy.injectCredentialsAndInvokeV2(createProfilingGroupRequestBuilder.build(), profilerClient::createProfilingGroup);
         });
         logger.log(format("%s [%s] for accountId [%s] has been successfully created!", ResourceModel.TYPE_NAME, pgName, awsAccountId));
 

--- a/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandlerTest.java
+++ b/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandlerTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.codeguruprofiler.model.CodeGuruProfilerException;
@@ -194,6 +196,27 @@ public class CreateHandlerTest {
                     }
                 }
             }
+        }
+    }
+
+    @Nested
+    class WhenComputePlatformIsSet {
+        @ParameterizedTest
+        @ValueSource(strings = {"Default", "AWSLambda"})
+        public void itSucceedsWithValidComputePlatformString(String computePlatform) {
+            CreateProfilingGroupRequest createProfilingGroupRequest = CreateProfilingGroupRequest.builder()
+                .profilingGroupName(profilingGroupName)
+                .computePlatform(computePlatform)
+                .clientToken(clientToken)
+                .build();
+
+            request = makeRequest(ResourceModel.builder().profilingGroupName(profilingGroupName)
+                .computePlatform(computePlatform).build());
+
+            assertSuccessfulResponse(subject.handleRequest(proxy, request, null, logger));
+
+            verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(createProfilingGroupRequest), any());
+            verifyNoMoreInteractions(proxy);
         }
     }
 

--- a/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandlerTest.java
+++ b/aws-codeguruprofiler-profilinggroup/src/test/java/software/amazon/codeguruprofiler/profilinggroup/CreateHandlerTest.java
@@ -213,7 +213,7 @@ public class CreateHandlerTest {
             request = makeRequest(ResourceModel.builder().profilingGroupName(profilingGroupName)
                 .computePlatform(computePlatform).build());
 
-            assertSuccessfulResponse(subject.handleRequest(proxy, request, null, logger));
+            assertSuccessfulResponse(subject.handleRequest(proxy, request, null, logger), computePlatform);
 
             verify(proxy, times(1)).injectCredentialsAndInvokeV2(eq(createProfilingGroupRequest), any());
             verifyNoMoreInteractions(proxy);
@@ -294,10 +294,15 @@ public class CreateHandlerTest {
     }
 
     private void assertSuccessfulResponse(ProgressEvent<ResourceModel, CallbackContext> response) {
+        assertSuccessfulResponse(response, null);
+    }
+
+    private void assertSuccessfulResponse(ProgressEvent<ResourceModel, CallbackContext> response, String computePlatform) {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getComputePlatform()).isEqualTo(computePlatform);
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
     }


### PR DESCRIPTION
*Description of changes:*

As CodeGuru Profiler has now support for lambda profiling groups, we would like to also cover that in Cloudformation. This change allows user to specify compute platform["AWSLambda"/"Default"] for ProfilingGroup at creation.

CreateProfilingGroup API with compute platform : https://docs.aws.amazon.com/codeguru/latest/profiler-api/API_CreateProfilingGroup.html#profiler-CreateProfilingGroup-request-computePlatform

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
