### PR TITLE
Make ComputePlatform a create only property

### DIFF
--- a/aws-codeguruprofiler-profilinggroup/aws-codeguruprofiler-profilinggroup.json
+++ b/aws-codeguruprofiler-profilinggroup/aws-codeguruprofiler-profilinggroup.json
@@ -64,7 +64,8 @@
     "/properties/Arn"
   ],
   "createOnlyProperties": [
-    "/properties/ProfilingGroupName"
+    "/properties/ProfilingGroupName",
+    "/properties/ComputePlatform"
   ],
   "handlers": {
     "create": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In this change I am adding `ComputePlatform` in the `createOnlyProperties` of the resource schema to make sure we don't get updates on this property.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
